### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://pt1442.visualstudio.com/61c5860e-d1f2-4169-ae21-f1c9a81dd706/450a8d0f-3df7-4e84-ad63-7848ad0b745b/_apis/work/boardbadge/6ea69447-f509-4632-b9cc-94ef0eb84aea)](https://pt1442.visualstudio.com/61c5860e-d1f2-4169-ae21-f1c9a81dd706/_boards/board/t/450a8d0f-3df7-4e84-ad63-7848ad0b745b/Microsoft.RequirementCategory)
 ![wired-brain-coffee-logo](https://user-images.githubusercontent.com/54862167/64559227-0abc8380-d303-11e9-999e-ccb9e86cf236.png)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://pt1442.visualstudio.com/61c5860e-d1f2-4169-ae21-f1c9a81dd706/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.